### PR TITLE
fix: 注册成功后报空指针异常

### DIFF
--- a/packages/mall-cook-platform/src/pages/login.vue
+++ b/packages/mall-cook-platform/src/pages/login.vue
@@ -183,7 +183,6 @@ export default {
               type: "success",
             });
             this.active = "login";
-            this.$refs["login"].resetFields();
             setTimeout(() => {
               this.$refs["login"].resetFields();
             }, 0);


### PR DESCRIPTION
这句代码重复了，会导致注册成功后报空指针异常，保留异步调用的那句即可