### PR TITLE
fix(component):jumpSelect面板中选择跳转后的文字展示

### DIFF
--- a/packages/mall-cook-platform/src/custom-schema-template/components/SchemaJump/index.vue
+++ b/packages/mall-cook-platform/src/custom-schema-template/components/SchemaJump/index.vue
@@ -10,7 +10,12 @@
   <config-item :label='label'>
     <div class="flex col-center h32">
       <div
-        v-if="!mValue.id"
+         v-if="
+          mValue.id === null ||
+          mValue.id === undefined ||
+          mValue.id === '' ||
+          (typeof mValue.id === 'number' && mValue.id < 0)
+        "
         class="f12 f-theme pointer"
         @click="open"
       >


### PR DESCRIPTION
`mall-cook-platform/src/config/project.js`， 这里id是`000000`,会导致判断错误

```
// 导航配置
export const navigation = {
  label: '导航',
  styles: {
    background: '#fff'
  },
  list: [
    {
      id: '00001',
      icon: 'icon-shop',
      text: '首页',
      jump: {
        type: 'custom',
        id: '000000'
      }
    },
    {
      id: '00003',
      icon: 'icon-sort',
      text: '分类',
      jump: {
        type: 'fixed',
        id: 'category'
      }
    },
    {
      id: '00004',
      icon: 'icon-cart',
      text: '购物车',
      jump: {
        type: 'fixed',
        id: 'car'
      }
    },
    {
      id: '00005',
      icon: 'icon-my',
      text: '我的',
      jump: {
        type: 'fixed',
        id: 'my'
      }
    }
  ]
}

```